### PR TITLE
fix: Set correct docker image name for cosign & trivy - fixes #2

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -137,7 +137,9 @@ jobs:
       - name: Set ENVs
         id: env-setup
         run: |
-          echo "DOCKER_IMAGE_TAG=${DOCKER_IMAGES%%,*}" >> "$GITHUB_OUTPUT"
+          export DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAMES%%,*}"
+          export DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAGS%%,*}"
+          echo "DOCKER_IMAGE=${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           for MY_VAR in $(echo "${{ inputs.extra-envs }}" | tr ";" "\n"); do
             echo "$MY_VAR" >> $GITHUB_ENV
             echo "$MY_VAR" >> $GITHUB_OUTPUT
@@ -159,7 +161,8 @@ jobs:
           COSIGN_KEY_OR_KMS: ${{ secrets.COSIGN_KEY_OR_KMS }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           REGISTRY_PW: ${{ secrets.REGISTRY_PW }}
-          DOCKER_IMAGES: ${{ inputs.build-tags }}
+          DOCKER_IMAGE_NAMES: ${{ inputs.build-name }}
+          DOCKER_IMAGE_TAGS: ${{ inputs.build-tags }}
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2
@@ -220,7 +223,7 @@ jobs:
         if: inputs.scan-image
         with:
           scan-type: image
-          image-ref: ${{ steps.env-setup.outputs.DOCKER_IMAGE_TAG }}
+          image-ref: ${{ steps.env-setup.outputs.DOCKER_IMAGE }}
           hide-progress: false
           format: sarif
           output: trivy-results.sarif
@@ -249,6 +252,7 @@ jobs:
       SIGN_SIGNATURES: ${{ steps.sign.outputs.SIGN_SIGNATURES }}
     if: needs.build-image.outputs.COSIGN_RUN == 'yes'
     needs: build-image
+    environment: ${{ inputs.environment }}
     steps:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
@@ -256,7 +260,9 @@ jobs:
       - name: Set ENVs
         id: env-setup
         run: |
-          echo "DOCKER_IMAGE_TAG=${DOCKER_IMAGES%%,*}" >> "$GITHUB_OUTPUT"
+          export DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAMES%%,*}"
+          export DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAGS%%,*}"
+          echo "DOCKER_IMAGE=${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           for MY_VAR in $(echo "${{ inputs.extra-envs }}" | tr ";" "\n"); do
             echo "$MY_VAR" >> $GITHUB_ENV
             echo "$MY_VAR" >> $GITHUB_OUTPUT
@@ -278,7 +284,8 @@ jobs:
           COSIGN_KEY_OR_KMS: ${{ secrets.COSIGN_KEY_OR_KMS }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           REGISTRY_PW: ${{ secrets.REGISTRY_PW }}
-          DOCKER_IMAGES: ${{ inputs.build-tags }}
+          DOCKER_IMAGE_NAMES: ${{ inputs.build-name }}
+          DOCKER_IMAGE_TAGS: ${{ inputs.build-tags }}
 
       - name: Log into registry ${{ inputs.oci-registry }}
         uses: docker/login-action@v2

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -321,8 +321,7 @@ jobs:
             echo "Cosign upload disabled."
             COSIGN_UPLOAD_ARGS="--upload=false"
           fi
-          for MY_IMG in $(echo "${{ inputs.build-tags }}" | tr "," "\n"); do
-            MY_IMG_NAME=$(echo $MY_IMG | cut -d ":" -f 1)
+          for MY_IMG_NAME in $(echo "${{ inputs.build-name }}" | tr "," "\n"); do
             MY_IMG_SIG_NAME=$(echo $MY_IMG_NAME | tr '/' '-')
             echo "Signing ${MY_IMG_NAME}@${{ needs.build-image.outputs.DOCKER_DIGEST }}..."
             echo "Running: cosign sign --key $COSIGN_KEY $COSIGN_UPLOAD_ARGS $COSIGN_EXTRA_ARGS \


### PR DESCRIPTION
Fixes a bug introduced in #03d93b657f4963f228645ce3a0c0053bfa0b242a

Docker Tag nname is now correctly set for cosign and trivy

Fixes #2 